### PR TITLE
fix: care page auto redirect to zh-cn

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Snapmaker-Copenhagen",
   "author": "Snapmaker",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -138,7 +138,7 @@
                         <div class="font-bw-1 title-3">Snapmaker Care</div>
                         <div class="font-bw-2 font-1 mt-xs">Comprehensive protection for your peace of mind.</div>
                         <div>
-                            <a href="https://support.snapmaker.com/hc/p/care" class="snmk-link-btn">Learn More</a>
+                            <a href="https://support.snapmaker.com/hc/en-us/p/care" class="snmk-link-btn">Learn More</a>
                         </div>
                     </div>
                     <div class="product-warranty px-xl py-2xl">
@@ -161,7 +161,7 @@
             <p class="font-bw-2 font-1 mt-m mb-xl">{{dc 'home_need_help_desc'}}</p>
             <div class="home-need-help-buttons">
                 <button class="snmk-primary-btn" onclick="zE(function() { zE.activate() });">{{t 'submit_a_request' }}</button>
-                <a class="snmk-btn" href="https://forum.snapmaker.com/">Visit the forum</a>
+                <a class="snmk-btn" href="https://forum.snapmaker.f/">Visit the forum</a>
             </div>
         </div>    
     </div>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -161,7 +161,7 @@
             <p class="font-bw-2 font-1 mt-m mb-xl">{{dc 'home_need_help_desc'}}</p>
             <div class="home-need-help-buttons">
                 <button class="snmk-primary-btn" onclick="zE(function() { zE.activate() });">{{t 'submit_a_request' }}</button>
-                <a class="snmk-btn" href="https://forum.snapmaker.f/">Visit the forum</a>
+                <a class="snmk-btn" href="https://forum.snapmaker.com/">Visit the forum</a>
             </div>
         </div>    
     </div>


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->